### PR TITLE
Add model provenance tracking to assistant messages

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,14 @@
         "shadcn@latest",
         "mcp"
       ]
+    },
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest"
+      ],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ The production build uses nginx reverse proxy to avoid CORS issues.
 - ✅ Theme/Appearance Selector - System/Light/Dark mode with localStorage persistence
 - ✅ Vision/Image Support - Upload images with text for vision-capable models
 - ✅ Projects Feature - Organize chats by project with custom instructions (persists to localStorage)
+- ✅ Model Provenance - Each assistant message displays which model generated it (persists to localStorage)
 
 ## Project Structure
 
@@ -247,6 +248,17 @@ Provides:
 3. Upload image (JPEG, PNG, WebP, GIF)
 4. Type your message
 5. Send - model will analyze image and respond
+
+## Model Provenance
+
+Each assistant message displays the model name that generated it (e.g., "gemma3:latest") for provenance tracking.
+
+**Implementation:**
+- Model stored in `metadata: { model }` when creating assistant messages
+- `convertMessage` in runtime maps `metadata` → `metadata.custom` for assistant-ui
+- `AssistantMessage` component reads via `useMessage((m) => m.metadata?.custom?.model)`
+- Works for both regular chat and project chat
+- Persists automatically via Zustand localStorage middleware
 
 ## Projects Feature
 

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -17,6 +17,7 @@ import {
   ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  useMessage,
 } from "@assistant-ui/react";
 
 import type { FC } from "react";
@@ -246,12 +247,25 @@ const MessageError: FC = () => {
 };
 
 const AssistantMessage: FC = () => {
+  // Access model name from metadata.custom (mapped by convertMessage in runtime)
+  const modelName = useMessage((m) => {
+    const custom = m.metadata?.custom as Record<string, unknown> | undefined;
+    return custom?.model as string | undefined;
+  });
+
   return (
     <MessagePrimitive.Root asChild>
       <div
         className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-150 ease-out fade-in slide-in-from-bottom-1 last:mb-24"
         data-role="assistant"
       >
+        {/* Model name label for provenance tracking */}
+        {modelName && (
+          <div className="aui-assistant-message-model mx-2 mb-1 text-xs text-muted-foreground/70">
+            {modelName}
+          </div>
+        )}
+
         <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
           <MessagePrimitive.Parts
             components={{

--- a/lib/ollama-external-runtime.tsx
+++ b/lib/ollama-external-runtime.tsx
@@ -107,6 +107,7 @@ async function streamOllamaResponse(
     status: {
       type: "running",
     },
+    metadata: { model: selectedModel },
   };
 
   chatStore.addMessage(assistantMessage);
@@ -374,12 +375,19 @@ export function OllamaRuntimeProvider({ children }: { children: ReactNode }) {
   );
 
   /**
-   * Convert message for assistant-ui (identity function since types match)
+   * Convert message for assistant-ui
+   * Maps our custom metadata to assistant-ui's metadata.custom field
    */
   const convertMessage = useCallback((message: ThreadMessageLike) => {
-    // Our messages are already in the correct format
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return message as any;  // Type assertion required by ExternalStoreRuntime
+    // Map our metadata to assistant-ui's expected structure
+    // Our metadata (e.g., { model: "gemma3:latest" }) goes into metadata.custom
+    return {
+      ...message,
+      metadata: {
+        custom: message.metadata || {},
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any; // Type assertion required by ExternalStoreRuntime
   }, []);
 
   /**

--- a/lib/ollama-project-runtime.tsx
+++ b/lib/ollama-project-runtime.tsx
@@ -119,6 +119,7 @@ async function streamOllamaResponse(
     status: {
       type: "running",
     },
+    metadata: { model: selectedModel },
   };
 
   projectStore.addProjectMessage(projectId, threadId, assistantMessage);
@@ -393,10 +394,18 @@ export function OllamaProjectRuntimeProvider({
 
   /**
    * Convert message for assistant-ui
+   * Maps our custom metadata to assistant-ui's metadata.custom field
    */
   const convertMessage = useCallback((message: ProjectThreadMessage) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return message as any;
+    // Map our metadata to assistant-ui's expected structure
+    // Our metadata (e.g., { model: "gemma3:latest" }) goes into metadata.custom
+    return {
+      ...message,
+      metadata: {
+        custom: message.metadata || {},
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any; // Type assertion required by ExternalStoreRuntime
   }, []);
 
   /**


### PR DESCRIPTION
## Summary
- Display model name (e.g., "gemma3:latest") above each assistant message for provenance tracking
- Store model in message metadata, map to assistant-ui's metadata.custom
- Works for both regular chat and project chat
- Persists automatically via Zustand localStorage middleware

## Test plan
- [x] New messages show model name
- [x] Model name persists after page reload
- [x] Works in regular chat threads
- [x] Works in project chat threads
- [x] Old messages without model metadata render correctly (no label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)